### PR TITLE
pigpio servo backend and 2S dual-BEC hardware docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI agents and automated tooling working in this repository.
 
 ## Project summary
 
-**Coco Walker** is control software for **Coco**, a small **bipedal** robot with **four hobby servos** (left/right foot and hip). The stack runs on a **Raspberry Pi Zero W** with an **Adafruit ServoKit** (PCA9685, 16 channels) and optional **Vue 2** web UI for gait design.
+**Coco Walker** is control software for **Coco**, a small **bipedal** robot with **four hobby servos** (left/right foot and hip). The stack runs on a **Raspberry Pi Zero W** with **pigpio** PWM on four GPIO lines (`servo_kit.py`), optional **Vue 2** web UI for gait design, and **2S 18650 + BMS** power via dual 5 V BECs.
 
 - **Repo**: [fanff/coco](https://github.com/fanff/coco) on GitHub
 - **Python**: 3.10+ via [uv](https://docs.astral.sh/uv/) (`pyproject.toml`, `uv.lock`)
@@ -17,13 +17,14 @@ frt/ (Vue UI)  --WebSocket-->  flsrv.py (port 8765)
                                     |
                               cocoWalker.py (interpolation thread)
                                     |
-                              ServoKit / mock
+                         servo_kit (pigpio / mock)
 ```
 
 | Component | Role |
 |-----------|------|
 | `cocoWalker.py` | `CocoWalker` class: threaded smooth servo moves; `setRot`, `move`, `setAtIv` |
-| `iv.py` | Home angles `iv=[...]` and motor name → channel map (`nameMap`) |
+| `iv.py` | Home angles `iv=[...]`, `servoGpios`, motor name → index map (`nameMap`) |
+| `servo_kit.py` | `make_servo_kit()`: pigpio, legacy ServoKit, or mock |
 | `flsrv.py` | Live sine gait + WebSocket control (`freqfact`, `amplfact`) |
 | `readPulp.py` | Playback of `file.json` keyframe curves (linear segments) |
 | `patterns/*.json` | Example saved gaits (normalized time `x`, offset `y` per motor) |
@@ -31,25 +32,24 @@ frt/ (Vue UI)  --WebSocket-->  flsrv.py (port 8765)
 
 ### Motor mapping (`iv.py`)
 
-| Name | Channel | Leg | Joint |
-|------|---------|-----|-------|
-| `feetL` | 0 | Left | Foot |
-| `feetR` | 1 | Right | Foot |
-| `hipR` | 2 | Right | Hip |
-| `hipL` | 3 | Left | Hip |
+| Name | Index | GPIO (BCM) | Leg | Joint |
+|------|-------|------------|-----|-------|
+| `feetL` | 0 | 17 | Left | Foot |
+| `feetR` | 1 | 18 | Right | Foot |
+| `hipR` | 2 | 27 | Right | Hip |
+| `hipL` | 3 | 22 | Left | Hip |
 
 Gait code applies per-motor scales in `flsrv.py` / `readPulp.py`: `[80, 80, -64, -64]` multiplied by pattern values before `setRot`.
 
 ## Hardware (do not assume in CI)
 
-- **Board**: **Raspberry Pi Zero W** + Adafruit 16-channel PWM/Servo HAT (PCA9685)
+- **Board**: **Raspberry Pi Zero W**; servos on GPIO via **pigpio** (`pigpiod` must be running)
 - **Servos**: 4× hobby servos; angles clamped 0–180° in `cocoWalker.py`
-- **Power** (two rails, common ground; see README):
-  - **Pi Zero W**: **5 V, ~1 A**
-  - **Servo bus** (HAT V+/GND): **5–6 V, 2–4 A** (prefer **3–4 A** for walking)
-- **Off-device**: `flsrv.py` catches import failures and uses `SKitMockup` / `ServoMockup` so gait logic runs without hardware.
+- **Power**: **2S** protected 18650 pack (**~7.4 V**) → two **5 V BECs** (Pi **~1 A**, servos **3–4 A**), **common ground**
+- **Legacy**: `COCO_SERVO_BACKEND=servokit` for Adafruit PCA9685 HAT (I2C)
+- **Off-device**: `make_servo_kit()` falls back to mock; set `COCO_SERVO_BACKEND=mock` explicitly in CI
 
-Enable I2C on the Pi Zero W before using real `ServoKit`. Do not document generic “any Pi” as the target board unless the user changes hardware.
+Do not document generic “any Pi” as the target board unless the user changes hardware.
 
 ## Commands agents should use
 
@@ -99,7 +99,7 @@ Used by `readPulp.py`, `file.json`, and `patterns/`:
 
 1. **Minimize scope** — Prefer small, focused changes. Do not refactor unrelated Flask experiments unless asked.
 2. **Match existing style** — Plain Python, minimal typing, `logging` for debug, threading in `cocoWalker.py`.
-3. **Preserve motor indices** — Changes to `nameMap` or channel order affect hardware wiring; update README table and any UI motor labels together.
+3. **Preserve motor indices** — Changes to `nameMap`, `servoGpios`, or index order affect wiring; update README GPIO table and any UI motor labels together.
 4. **Run via `uv run`** — Do not assume a global venv; use project lockfile.
 5. **Tests** — No formal test suite; `test.py` is a manual WebSocket check. Add tests only when requested or they cover non-trivial behavior.
 6. **Dependencies** — Edit `pyproject.toml` and run `uv lock` / `uv sync`; commit `uv.lock`.
@@ -113,7 +113,8 @@ Used by `readPulp.py`, `file.json`, and `patterns/`:
 | `cocoWalker.py` | Core motion; thread lifecycle (`startThread` / `stopThread`) |
 | `flsrv.py` | Asyncio + websockets; mock fallback |
 | `readPulp.py` | JSON sampling loop; `repeat`, `dursec`, `sleepPause` at top of file |
-| `iv.py` | Single source for home pose and names |
+| `iv.py` | Home pose, GPIO map, motor names |
+| `servo_kit.py` | pigpio / ServoKit / mock; pulse width mapping |
 | `frt/src/Cocoapp.vue` | WebSocket URL and UI |
 | `frt/src/components/cav.vue` | Canvas gait editor |
 | `README.md` | User-facing docs; keep in sync with behavior changes |
@@ -126,6 +127,7 @@ Used by `readPulp.py`, `file.json`, and `patterns/`:
 | Tune live walk speed/amplitude | `flsrv.py` (`forward`, `scales`, WebSocket keys) |
 | New recorded gait | `patterns/` or UI export → `file.json` |
 | Safer servo limits | `cocoWalker.py` (`nextposcapped` clamp) |
+| Change GPIO pins | `iv.py` (`servoGpios`) |
 | UI-only work | `frt/` |
 | Deps / Python version | `pyproject.toml`, `.python-version`, `uv.lock` |
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,40 @@
 # Coco Walker
 
-Software for **Coco**, a small **bipedal** walking robot. Coco has **two legs** and is driven by **four hobby servos**—a foot and a hip on each side (see `iv.py`). The repo runs on a Raspberry Pi (or similar) with an [Adafruit ServoKit](https://www.adafruit.com/product/2327) (PCA9685), and includes tools to design gaits, run them live, and control the robot from a browser.
+Software for **Coco**, a small **bipedal** walking robot. Coco has **two legs** and is driven by **four hobby servos**—a foot and a hip on each side (see `iv.py`). The repo runs on a **Raspberry Pi Zero W** with **pigpio** driving servo PWM on GPIO, and includes tools to design gaits, run them live, and control the robot from a browser.
 
 Python dependencies are managed with **[uv](https://docs.astral.sh/uv/)** (`pyproject.toml` + `uv.lock`).
 
 ## Hardware
 
-- **Computer**: Raspberry Pi Zero W (I2C enabled for the servo HAT)
+- **Computer**: Raspberry Pi Zero W
 - **Biped**: two legs, four degrees of freedom total
-- **4 servos** (2 per leg): foot + hip on left and right (channel mapping in `iv.py`)
-- **Servo driver**: Adafruit ServoKit (16-channel PCA9685 board)
+- **4 servos** (2 per leg): foot + hip on left and right (mapping in `iv.py`)
+- **Servo control**: [pigpio](https://abyz.me.uk/rpi/pigpio/) on four GPIO lines (`servoGpios` in `iv.py`); legacy PCA9685 ServoKit still supported via `servo_kit.py`
 - **3D-printed parts**: STL models in `3dmodels/` (`body.stl`, `leg.stl`, `feet.stl`)
 
 ### Power
 
-Use **two supplies** (common ground between Pi and HAT; do not power four servos from the Pi’s 5 V pin):
+**2S Li-ion** (two 18650 in series, **~7.4 V** nominal) through a **2S BMS**, then **two switching BECs** (common ground at the pack):
 
-| Rail | Typical supply | Notes |
-|------|----------------|--------|
-| **Pi Zero W** | **5 V, ~1 A** | Enough for Wi‑Fi and gait software; use a bit more headroom if you add USB peripherals. |
-| **Servo bus** (HAT screw terminals) | **5–6 V, 2–4 A** | **2 A** for light duty with small hobby servos; **3–4 A** safer when all four move or stall during walking. |
+| Rail | Source | Notes |
+|------|--------|--------|
+| **Pi Zero W** | 5 V BEC, **~1 A** | Do not power the Pi from the servo BEC. |
+| **Servo bus** | 5 V BEC, **3–4 A** | Servo **red/black** only from this rail—not from the Pi 5 V pin. |
 
-Servos must be **5 V–compatible**; PWM logic is **3.3 V** from the Pi. See the [Adafruit Servo HAT guide](https://learn.adafruit.com/adafruit-16-channel-pwm-servo-hat-for-raspberry-pi) for wiring.
+Use BECs with an input range that covers **~6–8.4 V** (full 2S span). Add bulk capacitance on the servo 5 V rail near the connectors.
 
-Neutral / home angles and motor names are defined in `iv.py`:
+Servo **signal** wires go to the Pi GPIO pins in `iv.py`. PWM is **3.3 V**; most hobby servos accept it. Tie Pi GND and servo GND together once (star ground).
 
-| Name   | Index | Leg   | Joint   |
-|--------|-------|-------|---------|
-| feetL  | 0     | Left  | Foot    |
-| feetR  | 1     | Right | Foot    |
-| hipR   | 2     | Right | Hip     |
-| hipL   | 3     | Left  | Hip     |
+### GPIO wiring (default)
+
+| Name   | Index | GPIO (BCM) | Leg   | Joint   |
+|--------|-------|------------|-------|---------|
+| feetL  | 0     | 17         | Left  | Foot    |
+| feetR  | 1     | 18         | Right | Foot    |
+| hipR   | 2     | 27         | Right | Hip     |
+| hipL   | 3     | 22         | Left  | Hip     |
+
+Change `servoGpios` in `iv.py` to match your harness. Home angles are in `iv=[...]`.
 
 ## How it works
 
@@ -39,11 +43,11 @@ Neutral / home angles and motor names are defined in `iv.py`:
         |                         |                              |
         +---- ws://host:8765 -----+---- cocoWalker.py ------------+
                                           |
-                                    ServoKit (or mock)
+                              servo_kit (pigpio / mock)
 ```
 
 1. **`cocoWalker.py`** — Core motion layer. A background thread smoothly interpolates each servo toward target angles; `move()` and `setRot()` update targets without blocking the gait loop.
-2. **`flsrv.py`** — Real-time walker. Sine-based forward gait on **port 8765**; accepts JSON (`freqfact`, `amplfact`) over WebSocket to adjust speed and amplitude. Uses ServoKit when available, otherwise a mock.
+2. **`flsrv.py`** — Real-time walker. Sine-based forward gait on **port 8765**; accepts JSON (`freqfact`, `amplfact`) over WebSocket to adjust speed and amplitude. Uses pigpio when the daemon is running, otherwise a mock.
 3. **`readPulp.py`** — Plays back keyframe curves from `file.json` (or UI exports), samples them with linear segments, and replays the motion a configurable number of times.
 4. **`patterns/`** — Example gait JSON (`forward.json`, `rotateCW.json`, …) with time-series points per leg.
 5. **`frt/`** — Vue 2 UI (`cocoui`) to draw leg curves per motor, export `file.json`, and connect over WebSocket. Set the host IP in the Vue sources to your board’s LAN address.
@@ -66,7 +70,15 @@ uv run python readPulp.py   # play file.json pattern (needs hardware)
 uv run python test.py       # WebSocket smoke test
 ```
 
-On a Raspberry Pi with ServoKit and I2C enabled, use the same commands after `uv sync`.
+On the Pi, install and start the pigpio daemon, then use the same commands after `uv sync`:
+
+```bash
+sudo apt install pigpio python3-pigpio   # or build from pigpio repo
+sudo pigpiod
+sudo systemctl enable pigpiod            # optional: start on boot
+```
+
+Set `COCO_SERVO_BACKEND=mock` to force the software mock (laptops/CI). Use `servokit` for the legacy Adafruit HAT.
 
 ### Web UI
 
@@ -83,7 +95,8 @@ npm run serve
 | `pyproject.toml` | Project metadata and Python dependencies |
 | `uv.lock` | Locked dependency versions (commit this file) |
 | `cocoWalker.py` | Servo controller with threaded interpolation |
-| `iv.py` | Initial angles and motor name map |
+| `iv.py` | Home angles, GPIO map, motor name map |
+| `servo_kit.py` | pigpio / ServoKit / mock factory |
 | `flsrv.py` | WebSocket gait server (port 8765) |
 | `readPulp.py` | JSON pattern sampler and playback |
 | `patterns/` | Saved gait curves |
@@ -94,7 +107,7 @@ npm run serve
 ## Notes
 
 - **Flask** packages are listed for experiments; the main control path uses **asyncio** and **websockets** in `flsrv.py`.
-- **Adafruit ServoKit** only talks to real hardware on supported boards (e.g. Raspberry Pi with I2C). Off-device, `flsrv.py` falls back to a mock.
+- **pigpio** needs `pigpiod` on the Pi. Off-device, `servo_kit.make_servo_kit()` falls back to a mock unless you set `COCO_SERVO_BACKEND`.
 - The UI references a LAN IP (e.g. `192.168.1.58`); change it to match your robot host.
 - `flsrv.py` accepts WebSocket messages as JSON with numeric fields such as `freqfact` and `amplfact` to tune the live gait.
 

--- a/flsrv.py
+++ b/flsrv.py
@@ -12,13 +12,7 @@ from pprint import pprint
 
 import cocoWalker
 from iv import iv,LEFTFEET,RIGHTFEET,LEFTHIP,RIGHTHIP,nameMap
-
-class ServoMockup():
-    def __setattr__(self,thing,value):
-        logging.info("setting %s : %s"%(thing,value))
-class SKitMockup():
-    def __init__(self):
-        self.servo = [ServoMockup() for i in range(16)]
+from servo_kit import make_servo_kit
 
 instantConfig={
         "freqfact":0.0,
@@ -52,12 +46,7 @@ def forward(freqfact=1,amplfact = 1.0):
 
 async def bgjob():
     log = logging.getLogger("bgjob")
-    try:
-        from adafruit_servokit import ServoKit
-        kit = ServoKit(channels=16)
-    except Exception as e:
-        log.warning("mocking up") 
-        kit = SKitMockup()
+    kit = make_servo_kit(log)
 
     coco = cocoWalker.CocoWalker(kit,iv)
     coco.setAtIv()

--- a/iv.py
+++ b/iv.py
@@ -1,6 +1,8 @@
 
-
 iv=[90,80,64,90]
+
+# BCM GPIO for pigpio (index order: feetL, feetR, hipR, hipL)
+servoGpios = [17, 18, 27, 22]
 
 LEFTFEET=0
 RIGHTFEET=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "flask-cors>=4.0",
     "flask-socketio>=5.0",
     "numpy>=1.26",
+    "pigpio>=1.78",
     "adafruit-circuitpython-servokit>=1.3",
     "websockets>=12.0",
     "websocket-client>=1.8",

--- a/readPulp.py
+++ b/readPulp.py
@@ -1,11 +1,11 @@
 
-from adafruit_servokit import ServoKit
 import time
 import logging
 import json
 from pprint import pprint
 import cocoWalker
 from iv import iv,LEFTFEET,RIGHTFEET,LEFTHIP,RIGHTHIP,nameMap
+from servo_kit import make_servo_kit
 
 
 def lin_equ(l1, l2):
@@ -69,7 +69,7 @@ for _ in range(int(sampling)):
 # play sampledPos
 scales = [80,80,-64,-64]
 
-kit = ServoKit(channels=16)
+kit = make_servo_kit()
 coco = cocoWalker.CocoWalker(kit,iv)
 coco.setAtIv()
 

--- a/servo_kit.py
+++ b/servo_kit.py
@@ -1,0 +1,139 @@
+"""Servo backends for Coco: pigpio (GPIO), optional legacy ServoKit, or mock."""
+
+import logging
+import os
+import socket
+
+# BCM pins: feetL, feetR, hipR, hipL (same order as iv channel indices)
+from iv import servoGpios
+
+PULSE_MIN_US = 500
+PULSE_MAX_US = 2500
+
+
+def angle_to_pulse_us(angle):
+    angle = max(0.0, min(180.0, float(angle)))
+    span = PULSE_MAX_US - PULSE_MIN_US
+    return int(PULSE_MIN_US + (angle / 180.0) * span)
+
+
+class ServoMockup:
+    def __init__(self, index):
+        self.index = index
+
+    @property
+    def angle(self):
+        return None
+
+    @angle.setter
+    def angle(self, value):
+        logging.getLogger("servo.mock").info("servo[%s].angle = %s", self.index, value)
+
+
+class SKitMockup:
+    def __init__(self, n_motors=4):
+        self.servo = [ServoMockup(i) for i in range(n_motors)]
+
+    def close(self):
+        pass
+
+
+class _ServoAngle:
+    __slots__ = ("_set_angle",)
+
+    def __init__(self, set_angle):
+        self._set_angle = set_angle
+
+    @property
+    def angle(self):
+        return None
+
+    @angle.setter
+    def angle(self, value):
+        self._set_angle(value)
+
+
+class PigpioKit:
+    def __init__(self, pi, gpios):
+        self._pi = pi
+        self._gpios = list(gpios)
+        self.servo = [
+            _ServoAngle(lambda a, g=gpio: self._write(g, a))
+            for gpio in self._gpios
+        ]
+        log = logging.getLogger("servo.pigpio")
+        for gpio in self._gpios:
+            self._pi.set_mode(gpio, self._pi.OUTPUT)
+            log.info("servo on GPIO %s", gpio)
+
+    def _write(self, gpio, angle):
+        pulse = angle_to_pulse_us(angle)
+        self._pi.set_servo_pulsewidth(gpio, pulse)
+
+    def close(self):
+        for gpio in self._gpios:
+            self._pi.set_servo_pulsewidth(gpio, 0)
+        self._pi.stop()
+
+
+def _pigpiod_running(host=None, port=None):
+    host = host or os.environ.get("PIGPIO_ADDR", "localhost")
+    port = int(port or os.environ.get("PIGPIO_PORT", "8888"))
+    try:
+        with socket.create_connection((host, port), timeout=0.2):
+            return True
+    except OSError:
+        return False
+
+
+def _make_pigpio_kit(log):
+    if not _pigpiod_running():
+        raise RuntimeError("pigpio daemon not running (start with: sudo pigpiod)")
+
+    import pigpio
+
+    pi = pigpio.pi()
+    if not pi.connected:
+        pi.stop()
+        raise RuntimeError("pigpio daemon not running (start with: sudo pigpiod)")
+    log.info("using pigpio on GPIOs %s", servoGpios)
+    return PigpioKit(pi, servoGpios)
+
+
+def _make_servokit(log):
+    from adafruit_servokit import ServoKit
+
+    kit = ServoKit(channels=16)
+    log.info("using Adafruit ServoKit (legacy PCA9685)")
+    return kit
+
+
+def make_servo_kit(logger=None):
+    """
+    Return a kit object with .servo[i].angle for i in 0..3.
+    Backend order: COCO_SERVO_BACKEND env, else pigpio, ServoKit, mock.
+    """
+    log = logger or logging.getLogger("servo")
+    backend = os.environ.get("COCO_SERVO_BACKEND", "").strip().lower()
+
+    if backend == "mock":
+        log.warning("COCO_SERVO_BACKEND=mock")
+        return SKitMockup()
+
+    if backend == "servokit":
+        return _make_servokit(log)
+
+    if backend == "pigpio":
+        return _make_pigpio_kit(log)
+
+    for name, factory in (
+        ("pigpio", _make_pigpio_kit),
+        ("servokit", _make_servokit),
+    ):
+        try:
+            return factory(log)
+        except Exception as e:
+            log.warning("%s unavailable: %s", name, e)
+
+    log.warning("using servo mock (no hardware backend)")
+    return SKitMockup()

--- a/uv.lock
+++ b/uv.lock
@@ -206,6 +206,7 @@ dependencies = [
     { name = "flask-socketio" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pigpio" },
     { name = "websocket-client" },
     { name = "websockets" },
 ]
@@ -217,6 +218,7 @@ requires-dist = [
     { name = "flask-cors", specifier = ">=4.0" },
     { name = "flask-socketio", specifier = ">=5.0" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "pigpio", specifier = ">=1.78" },
     { name = "websocket-client", specifier = ">=1.8" },
     { name = "websockets", specifier = ">=12.0" },
 ]
@@ -537,6 +539,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
     { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
     { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "pigpio"
+version = "1.78"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/4a/3ebdfd90906553fb5420e80a475eb52f0809f2a29b547ba3b260db0cbc8f/pigpio-1.78.tar.gz", hash = "sha256:91efa50e4990649da97408a384782d6ccf58342fc59cdfe21ed7a42911569975", size = 40738, upload-time = "2020-09-29T23:55:12.61Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/a0/991ac7f96f83936c15f4b26b51d1fdba63e7bc9866411bfda022b649c2a7/pigpio-1.78-py2.py3-none-any.whl", hash = "sha256:81e46f640c4e6342881fa9bbe290dbcd4fc179619dc6591e57a9d4a084dc49fa", size = 39622, upload-time = "2020-09-29T23:55:11.013Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adopts the renovated Coco hardware plan discussed in issue context:

- **Power**: 2S 18650 pack with BMS → dual 5 V BECs (Pi vs servos), documented in README/AGENTS.md
- **Servos**: Primary control via **pigpio** on four GPIO lines; legacy Adafruit ServoKit still available via `COCO_SERVO_BACKEND=servokit`

## Changes

- New `servo_kit.py` with `make_servo_kit()` (pigpio → ServoKit → mock)
- Default BCM pins in `iv.servoGpios`: 17, 18, 27, 22 (feetL, feetR, hipR, hipL)
- `flsrv.py` and `readPulp.py` use the shared factory
- Added `pigpio` dependency; checks for `pigpiod` before connecting to avoid noisy failures off-device

## On the Pi

```bash
sudo apt install pigpio python3-pigpio
sudo pigpiod
uv sync
uv run python flsrv.py
```

Force mock on laptop/CI: `COCO_SERVO_BACKEND=mock`

## Wiring reminder

- Servo **power** from motor BEC only; **signal** to GPIO; **common ground** with Pi
- Adjust `servoGpios` in `iv.py` to match your harness
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e1778f8b-72ed-487d-a8f8-396ee1dd106c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e1778f8b-72ed-487d-a8f8-396ee1dd106c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

